### PR TITLE
chore: remove ONLYOFFICE_GENERATE_FONTS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ ONLYOFFICE_AMQP_PORT="5672"
 
 # Specifies the enabling the wopi handlers.
 ONLYOFFICE_WOPI_ENABLED="false"
-
-# Regenerate the fonts list and the fonts thumbnails.
-ONLYOFFICE_GENERATE_FONTS="false"
 ```
 
 ## Build

--- a/overlay/usr/bin/entrypoint
+++ b/overlay/usr/bin/entrypoint
@@ -27,11 +27,6 @@ sed 's/\(^.\+"level":\s*"\).\+\(".*$\)/\1'"${ONLYOFFICE_LOG_LEVEL:-INFO}"'\2/g' 
 
 /usr/local/bin/gomplate -o /etc/onlyoffice/documentserver/environment -f /etc/templates/environment.tmpl
 
-if [ "${ONLYOFFICE_GENERATE_FONTS}" == "true" ]; then
-    log_info "Regenerate the fonts list and thumbnails"
-    documentserver-generate-allfonts.sh true
-fi
-
 log_info "Migrating Onlyoffice database"
 upgrade_mysql_tbl
 


### PR DESCRIPTION
This option was never working due to the 2-steps build process where the `documentserver-generate-allfonts.sh` is not part of the final image.